### PR TITLE
Call send_message always via a callback.

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -393,7 +393,8 @@ static int notify_fetching_peer(struct state_or_method *s, struct fetch *f,
 		cJSON_Delete(root);
 		return -1;
 	}
-	if (unlikely(send_message(f->peer, rendered_message,
+	struct peer *p = f->peer;
+	if (unlikely(p->send_message(p, rendered_message,
 			strlen(rendered_message)) != 0)) {
 		cJSON_Delete(root);
 		free(rendered_message);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -257,7 +257,8 @@ static const char *get_response(unsigned int status_code)
 static int send_http_error_response(struct ws_peer *ws_peer, unsigned int status_code)
 {
 	const char *response = get_response(status_code);
-	return send_message(&ws_peer->peer, response, strlen(response));
+	struct peer *p = &ws_peer->peer;
+	return p->send_message(p, response, strlen(response));
 }
 
 void http_init(struct ws_peer *p)

--- a/src/info.c
+++ b/src/info.c
@@ -103,7 +103,7 @@ int handle_info(const cJSON *json_rpc, struct peer *p)
 	char *rendered = cJSON_PrintUnformatted(result);
 	cJSON_Delete(result);
 	if (likely(rendered != NULL)) {
-		int ret = send_message(p, rendered, strlen(rendered));
+		int ret = p->send_message(p, rendered, strlen(rendered));
 		cJSON_free(rendered);
 		return ret;
 	} else {

--- a/src/parse.c
+++ b/src/parse.c
@@ -106,7 +106,7 @@ static int possibly_send_response(const cJSON *json_rpc, cJSON *error, struct pe
 			ret = -1;
 			goto render_error;
 		}
-		ret = send_message(p, rendered, strlen(rendered));
+		ret = p->send_message(p, rendered, strlen(rendered));
 		cJSON_free(rendered);
 	render_error:
 		cJSON_Delete(root);

--- a/src/peer.c
+++ b/src/peer.c
@@ -84,6 +84,11 @@ static int init_peer(struct peer *p, enum peer_type type, int fd, eventloop_func
 {
 	p->ev.context.fd = fd;
 	p->type = type;
+	if (type == JET) {
+		p->send_message = send_message;
+	} else {
+		p->send_message = NULL;
+	}
 	p->ev.read_function = read_function;
 	p->ev.write_function = 	write_msg;
 	p->ev.error_function = error_function;

--- a/src/peer.h
+++ b/src/peer.h
@@ -50,6 +50,7 @@ enum peer_type { JET, JETWS };
 
 struct peer {
 	struct io_event ev;
+	int (*send_message)(struct peer *p, const char *rendered, size_t len);
 	int op;
 	unsigned int to_write;
 	uint32_t msg_length;

--- a/src/router.c
+++ b/src/router.c
@@ -136,7 +136,7 @@ static int format_and_send_response(struct peer *p, const cJSON *response)
 {
 	char *rendered = cJSON_PrintUnformatted(response);
 	if (likely(rendered != NULL)) {
-		int ret = send_message(p, rendered, strlen(rendered));
+		int ret = p->send_message(p, rendered, strlen(rendered));
 		cJSON_free(rendered);
 		return ret;
 	} else {

--- a/src/state.c
+++ b/src/state.c
@@ -211,7 +211,7 @@ cJSON *set_or_call(struct peer *p, const char *path, const cJSON *value,
 						  "could not render message");
 		goto delete_value_copy;
 	}
-	if (unlikely(send_message(s->peer, rendered_message,
+	if (unlikely(s->peer->send_message(s->peer, rendered_message,
 				  strlen(rendered_message)) != 0)) {
 		error = create_internal_error(
 			p, "reason", "could not send routing information");

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -65,9 +65,16 @@ MESSAGE(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 MESSAGE(STATUS "Target Processor: ${CMAKE_SYSTEM_PROCESSOR}")
 
 SET(INFO_TEST
+	../fetch.c
 	../info.c
 	../json/cJSON.c
+	../linux/jet_string.c
+	../linux/uuid.c
+	../peer.c
 	../response.c
+	../router.c
+	../state.c
+	../table.c
 	info_test.cpp
 	log.cpp
 )

--- a/src/tests/config_test.cpp
+++ b/src/tests/config_test.cpp
@@ -37,6 +37,14 @@
 #include "state.h"
 
 extern "C" {
+	int send_message(struct peer *p, const char *rendered, size_t len)
+	{
+		(void)p;
+		(void)rendered;
+		(void)len;
+		return 0;
+	}
+
 	enum callback_return handle_all_peer_operations(union io_context *context)
 	{
 		(void)context;
@@ -59,6 +67,7 @@ extern "C" {
 		(void)context;
 		return CONTINUE_LOOP;
 	}
+
 	void remove_routing_info_from_peer(const struct peer *p)
 	{
 		(void)p;

--- a/src/tests/info_test.cpp
+++ b/src/tests/info_test.cpp
@@ -37,10 +37,22 @@
 static char readback_buffer[10000];
 
 extern "C" {
-	void log_peer_err(const struct peer *p, const char *fmt, ...)
+
+	enum callback_return handle_all_peer_operations(union io_context *context)
+	{
+		(void)context;
+		return CONTINUE_LOOP;
+	}
+
+	void http_init(struct ws_peer *p)
 	{
 		(void)p;
-		(void)fmt;
+	}
+
+	enum callback_return handle_ws_upgrade(union io_context *context)
+	{
+		(void)context;
+		return CONTINUE_LOOP;
 	}
 
 	int send_message(struct peer *p, const char *rendered, size_t len)
@@ -52,6 +64,23 @@ extern "C" {
 		ptr += 4;
 		memcpy(ptr, rendered, len);
 		return 0;
+	}
+
+	enum callback_return write_msg(union io_context *context)
+	{
+		(void)context;
+		return CONTINUE_LOOP;
+	}
+
+	enum callback_return eventloop_add_io(struct io_event *ev)
+	{
+		(void)ev;
+		return CONTINUE_LOOP;
+	}
+
+	void eventloop_remove_io(struct io_event *ev)
+	{
+		(void)ev;
 	}
 }
 
@@ -70,8 +99,9 @@ static cJSON *create_correct_info_method()
 
 BOOST_AUTO_TEST_CASE(create_info)
 {
+	struct peer *p = alloc_jet_peer(-1);
 	cJSON *json_rpc = create_correct_info_method();
-	int ret = handle_info(json_rpc, NULL);
+	int ret = handle_info(json_rpc, p);
 	cJSON_Delete(json_rpc);
 	BOOST_CHECK(ret == 0);
 
@@ -141,5 +171,7 @@ BOOST_AUTO_TEST_CASE(create_info)
 	BOOST_CHECK((::strcmp(fetch->valuestring, "full") == 0) || (::strcmp(fetch->valuestring, "simple")));
 
 	cJSON_Delete(root);
+
+	free_peer(p);
 }
 

--- a/src/tests/log.cpp
+++ b/src/tests/log.cpp
@@ -44,3 +44,9 @@ char *get_log_buffer(void)
 {
 	return log_buffer;
 }
+
+void log_peer_err(const struct peer *p, const char *fmt, ...)
+{
+	(void) p;
+	(void)fmt;
+}

--- a/src/tests/peer_test.cpp
+++ b/src/tests/peer_test.cpp
@@ -41,6 +41,15 @@ enum fds {
 
 extern "C" {
 
+
+	int send_message(struct peer *p, const char *rendered, size_t len)
+	{
+		(void)p;
+		(void)rendered;
+		(void)len;
+		return 0;
+	}
+
 	enum callback_return handle_all_peer_operations(union io_context *context)
 	{
 		(void)context;


### PR DESCRIPTION
This is a prerequisite to send messages via websockets later on.
