### PR TITLE
Correct error handling.

### DIFF
--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(test_close_frame_on_websocket_free)
 	bool is_server = true;
 	F f(is_server);
 	
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(is_close_frame(), "No close frame sent when freeing the websocket!");
 }
 
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(test_receive_text_message_on_server)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_TEXT, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(text_message_received_called, "Callback for text messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_receive_text_message_on_client)
 	char message[] = "Tell me why!";
 	prepare_message(WS_OPCODE_TEXT, message, is_server, NULL);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(text_message_received_called, "Callback for text messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(test_receive_ping_frame_on_server)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_PING, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(ping_received_called, "Callback for ping messages was not called!");
 	BOOST_CHECK_MESSAGE(is_pong_frame(message), "No pong frame sent when ping received!");
 }
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(test_receive_ping_frame_on_client)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_PING, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(ping_received_called, "Callback for ping messages was not called!");
 	BOOST_CHECK_MESSAGE(is_pong_frame(message), "No pong frame sent when ping received!");
 }
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(test_receive_pong_on_server)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_PONG, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(pong_received_called, "Callback for pong messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(test_receive_pong_on_client)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_PONG, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(pong_received_called, "Callback for pong messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(test_receive_binary_message_on_server)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_BINARY, message, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(binary_message_received_called, "Callback for binary messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(test_receive_binary_message_on_client)
 	char message[] = "Tell me why!";
 	prepare_message(WS_OPCODE_BINARY, message, is_server, NULL);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	websocket_free(&f.ws);
+	websocket_free(&f.ws, 1001);
 	BOOST_CHECK_MESSAGE(binary_message_received_called, "Callback for binary messages was not called!");
 	BOOST_CHECK_MESSAGE(::strncmp(message, (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 }

--- a/src/tests/websocket_test.cpp
+++ b/src/tests/websocket_test.cpp
@@ -310,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE(test_websocket_init, F)
 	struct websocket ws;
 	int ret = websocket_init(&ws, connection, true, ws_on_error, "soap");
 	BOOST_CHECK_MESSAGE(ret == 0, "Initializaton of websocket failed!");
-	websocket_free(&ws);
+	websocket_free(&ws, 1001);
 }
 
 BOOST_AUTO_TEST_CASE(test_websocket_init_without_error_callback)
@@ -354,7 +354,7 @@ BOOST_FIXTURE_TEST_CASE(http_upgrade_with_websocket_protocol, F)
 
 	bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 	BOOST_CHECK_MESSAGE(ret == BS_OK, "websocket_read_header_line did not return expected return value");
-	websocket_free(&ws);
+	websocket_free(&ws, 1001);
 	if (ret == BS_OK) {
 		BOOST_CHECK_MESSAGE(ws_error == false, "Got error while parsing response for correct upgrade request");
 		BOOST_CHECK_MESSAGE(response_parser.status_code == 101, "Expected 101 status code");
@@ -395,7 +395,6 @@ BOOST_FIXTURE_TEST_CASE(http_upgrade_with_illegal_websocket_key, F)
 
 	bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 	BOOST_CHECK_MESSAGE(ret == BS_CLOSED, "websocket was not closed when illegal WebSocketKey was provided!");
-	websocket_free(&ws);
 }
 
 BOOST_FIXTURE_TEST_CASE(http_upgrade_with_unsupported_websocket_protocol, F)
@@ -426,7 +425,6 @@ BOOST_FIXTURE_TEST_CASE(http_upgrade_with_unsupported_websocket_protocol, F)
 	bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 	BOOST_CHECK_MESSAGE(ret == BS_CLOSED, "websocket was not closed when websocket upgrade contains only unsupported sub protocols");
 	BOOST_CHECK_MESSAGE(ws_error == true, "on_error function was not called when websocket upgrade contains only unsupported sub protocols");
-	websocket_free(&ws);
 }
 
 BOOST_AUTO_TEST_CASE(test_http_upgrade_http_version)
@@ -461,10 +459,9 @@ BOOST_AUTO_TEST_CASE(test_http_upgrade_http_version)
 		
 		bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 		BOOST_CHECK_MESSAGE(ret == table[i].expected_return, "websocket_read_header_line did not return expected return value");
-		websocket_free(&ws);
 		if (ret == BS_OK) {
+			websocket_free(&ws, 1001);
 			BOOST_CHECK_MESSAGE(ws_error == false, "Got error while parsing response for correct upgrade request");
-			
 			BOOST_CHECK_MESSAGE(response_parser.status_code == 101, "Expected 101 status code");
 			BOOST_CHECK_MESSAGE(response_parser.http_major == 1, "Expected http major 1");
 			BOOST_CHECK_MESSAGE(response_parser.http_minor == 1, "Expected http minor 1");
@@ -506,10 +503,9 @@ BOOST_AUTO_TEST_CASE(test_http_upgrade_wrong_ws_version)
 
 		bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 		BOOST_CHECK_MESSAGE(ret == table[i].expected_return, "websocket_read_header_line did not return expected return value");
-		websocket_free(&ws);
 		if (ret == BS_OK) {
+			websocket_free(&ws, 1001);
 			BOOST_CHECK_MESSAGE(ws_error == false, "Got error while parsing response for correct upgrade request");
-
 		} else {
 			BOOST_CHECK_MESSAGE(ws_error == true, "Wrong websocket version accepted!");
 		}
@@ -543,9 +539,9 @@ BOOST_AUTO_TEST_CASE(test_http_upgrade_wrong_http_method)
 
 		bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 		BOOST_CHECK_MESSAGE(ret == table[i].expected_return, "websocket_read_header_line did not return expected return value");
-		websocket_free(&ws);
 		if (ret == BS_OK) {
 			BOOST_CHECK_MESSAGE(ws_error == false, "Got error while parsing response for correct upgrade request");
+			websocket_free(&ws, 1001);
 		} else {
 			BOOST_CHECK_MESSAGE(ws_error == true, "Illegal http method accepted!");
 		}
@@ -564,7 +560,7 @@ BOOST_FIXTURE_TEST_CASE(test_http_only_header_parts, F)
 
 	bs_read_callback_return ret = websocket_read_header_line(&ws, (uint8_t *)&data[0], data.size());
 	BOOST_CHECK_MESSAGE(ret == BS_OK, "websocket_read_header_line did not return expected return value");
-	websocket_free(&ws);
+	websocket_free(&ws, 1001);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_close_while_reading_http_headers, F)
@@ -576,5 +572,4 @@ BOOST_FIXTURE_TEST_CASE(test_close_while_reading_http_headers, F)
 	bs_read_callback_return ret = websocket_read_header_line(&ws, NULL, 0);
 	BOOST_CHECK_MESSAGE(ret == BS_CLOSED, "websocket_read_header_line did not return expected return value");
 	BOOST_CHECK_MESSAGE(ws_error, "error function was not called socket was closed during header read!");
-	websocket_free(&ws);
 }

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -75,7 +75,7 @@ struct websocket {
 	enum websocket_callback_return (*binary_frame_received)(struct websocket *s, uint8_t *msg, size_t length, bool is_last_frame);
 	enum websocket_callback_return (*ping_received)(struct websocket *s, uint8_t *msg, size_t length);
 	enum websocket_callback_return (*pong_received)(struct websocket *s, uint8_t *msg, size_t length);
-	enum websocket_callback_return (*close_received)(struct websocket *s, uint16_t status_code, char *msg, size_t length);
+	enum websocket_callback_return (*close_received)(struct websocket *s, uint16_t status_code);
 	bool protocol_requested;
 	struct {
 		const char *name;
@@ -87,7 +87,7 @@ int websocket_init_random(void);
 void websocket_fill_mask_randomly(uint8_t mask[4]);
 
 int websocket_init(struct websocket *ws, struct http_connection *connection, bool is_server, void (*on_error)(struct websocket *s), const char *sub_protocol);
-void websocket_free(struct websocket *ws);
+void websocket_free(struct websocket *ws, uint16_t status_code);
 enum bs_read_callback_return websocket_read_header_line(void *context, uint8_t *buf, size_t len);
 enum bs_read_callback_return ws_get_header(void *context, uint8_t *buf, size_t len);
 


### PR DESCRIPTION
Always close the websocket before the error callback is called.
