### PR TITLE
Ignore incoming routing responses after timeout.

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -241,10 +241,12 @@ int handle_routing_response(const cJSON *json_rpc, const cJSON *response, const 
 			}
 			cJSON_Delete(request->origin_request_id);
 		}
-		cjet_free(request);
-	}
 
-	return ret;
+		cjet_free(request);
+		return ret;
+	} else {
+		return 0;
+	}
 }
 
 static void send_shutdown_response(const struct peer *p,

--- a/src/tests/state_test.cpp
+++ b/src/tests/state_test.cpp
@@ -760,7 +760,7 @@ BOOST_FIXTURE_TEST_CASE(set_with_timeout_before_response, F)
 	cJSON_Delete(error_message);
 
 	int ret = handle_routing_response(response, result, "result", &p);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK_MESSAGE(ret == 0, "Response after timeout not silently ignored!");
 
 	cJSON_Delete(routed_message);
 	cJSON_Delete(response);
@@ -793,7 +793,7 @@ BOOST_FIXTURE_TEST_CASE(set_with_destroy_before_response, F)
 	free_peer_resources(&setter_peer);
 
 	int ret = handle_routing_response(response, result, "result", &p);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK_MESSAGE(ret == 0, "Response after timeout/destroy not silently ignored!");
 
 	cJSON_Delete(routed_message);
 	cJSON_Delete(response);


### PR DESCRIPTION
Until this commit, an incoming response for a routed request was
treated like an error. The lead to the situation that the connection
to the peer sending the response was just closed. This also lead to a
remove of all states/elements belonging to that peer.