### PR TITLE
peer.h: removed unused import http_parser.h

### DIFF
--- a/src/peer.h
+++ b/src/peer.h
@@ -34,7 +34,6 @@
 
 #include "groups.h"
 #include "eventloop.h"
-#include "http-parser/http_parser.h"
 #include "json/cJSON.h"
 #include "list.h"
 


### PR DESCRIPTION
removed unused import http_parser from peer.h.