### PR TITLE
Feature/compiler: unused functions / memory barrier / format

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -26,6 +26,9 @@
 
 #include "base64.h"
 
+#include <string.h>
+
+
 static const char encode_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 void b64_encode_string(const uint8_t *RESTRICT in, size_t in_len, char *RESTRICT out)

--- a/src/base64.c
+++ b/src/base64.c
@@ -24,12 +24,7 @@
  * SOFTWARE.
  */
 
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
-
 #include "base64.h"
-#include "compiler.h"
 
 static const char encode_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/src/base64.h
+++ b/src/base64.h
@@ -30,11 +30,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void b64_encode_string(const uint8_t *restrict in, size_t in_len, char *restrict out);
+void b64_encode_string(const uint8_t *RESTRICT in, size_t in_len, char *RESTRICT out);
 static inline size_t b64_encoded_string_length(size_t input_length)
 {
 	return 4 * ((input_length + 2) / 3);

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -36,6 +36,10 @@
 	
 #define RESTRICT restrict
 
+#define ATTRIBUTE(x) __attribute__(x)
+
+#define INET <arpa/inet.h>
+
 #elif _MSC_VER
 
 #define likely(x) \
@@ -44,6 +48,10 @@
 	(x)
 	
 #define RESTRICT __restrict
+
+#define ATTRIBUTE(x)
+
+#define INET <WinSock2.h>
 
 #endif
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -40,6 +40,8 @@
 
 #define INET <arpa/inet.h>
 
+#define wmb() __sync_synchronize()
+
 #elif _MSC_VER
 
 #define likely(x) \
@@ -52,6 +54,8 @@
 #define ATTRIBUTE(x)
 
 #define INET <WinSock2.h>
+
+#define wmb() MemoryBarrier()
 
 #endif
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -65,13 +65,14 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "compiler.h"
 #include "alloc.h"
+
 
 #define GFP_KERNEL 1
 
 #define kmalloc(size, priority) cjet_malloc(size)
 #define kfree(__ptr) cjet_free(__ptr)
-#define wmb() __sync_synchronize()
 
 #define HASHTABLE_SUCCESS 0
 #define HASHTABLE_FULL -1

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -124,7 +124,7 @@ static const uint64_t hash64_magic = 0xd43ece626aa9260aULL;
 		return;                                                                                                                                                           \
 	}                                                                                                                                                                         \
                                                                                                                                                                                   \
-	_Pragma("GCC diagnostic ignored \"-Wunused-function\"") static inline int hashtable_get_##name(struct hashtable_##type_name *table, type key, struct value_##name *value) \
+ATTRIBUTE((unused)) static inline int hashtable_get_##name(struct hashtable_##type_name *table, type key, struct value_##name *value) \
 	{                                                                                                                                                                         \
 		uint32_t hash_pos = hash_func_##name##_##type_name(key);                                                                                                          \
 		uint32_t pos = hash_pos;                                                                                                                                          \
@@ -139,9 +139,7 @@ static const uint64_t hash64_magic = 0xd43ece626aa9260aULL;
 		}                                                                                                                                                                 \
 		return HASHTABLE_INVALIDENTRY;                                                                                                                                    \
 	}                                                                                                                                                                         \
-	_Pragma("GCC diagnostic error \"-Wunused-function\"")                                                                                                                     \
-                                                                                                                                                                                  \
-	    static inline uint32_t hop_range_##name(void)                                                                                                                         \
+ATTRIBUTE((unused)) static inline uint32_t hop_range_##name(void)                                                                                                                         \
 	{                                                                                                                                                                         \
 		return sizeof(((struct hashtable_##type_name *)0)->hop_info) * 8;                                                                                                 \
 	}                                                                                                                                                                         \

--- a/src/peer.c
+++ b/src/peer.c
@@ -24,11 +24,17 @@
  * SOFTWARE.
  */
 
+#include "peer.h"
 #include "compiler.h"
 #include INET
 
-#include "peer.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "alloc.h"
+#include "jet_string.h"
 #include "log.h"
+#include "router.h"
 
 static LIST_HEAD(peer_list);
 

--- a/src/peer.c
+++ b/src/peer.c
@@ -24,24 +24,11 @@
  * SOFTWARE.
  */
 
-#include <arpa/inet.h>
-
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <unistd.h>
-
-#include "alloc.h"
 #include "compiler.h"
-#include "element.h"
-#include "fetch.h"
-#include "jet_string.h"
-#include "list.h"
-#include "log.h"
+#include INET
+
 #include "peer.h"
-#include "router.h"
-#include "util.h"
-#include "json/cJSON.h"
+#include "log.h"
 
 static LIST_HEAD(peer_list);
 
@@ -133,7 +120,7 @@ void destroy_all_peers(void)
 }
 
 #define LOG_BUFFER_SIZE 100
-__attribute__((format(printf, 2, 3)))
+ATTRIBUTE((format(printf, 2, 3)))
 void log_peer_err(const struct peer *p, const char *fmt, ...)
 {
 	int written;
@@ -148,7 +135,7 @@ void log_peer_err(const struct peer *p, const char *fmt, ...)
 	log_err("%s", buffer);
 }
 
-__attribute__((format(printf, 2, 3)))
+ATTRIBUTE((format(printf, 2, 3)))
 void log_peer_info(const struct peer *p, const char *fmt, ...)
 {
 	int written;

--- a/src/socket_peer.c
+++ b/src/socket_peer.c
@@ -24,18 +24,15 @@
  * SOFTWARE.
  */
 
-#include <arpa/inet.h>
-#include <stdint.h>
-#include <unistd.h>
+#include "socket_peer.h"
+
+#include "compiler.h"
+#include INET
 
 #include "alloc.h"
-#include "buffered_reader.h"
-#include "compiler.h"
-#include "jet_endian.h"
 #include "log.h"
 #include "parse.h"
-#include "router.h"
-#include "socket_peer.h"
+
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))


### PR DESCRIPTION
- removed unnecessary inclusions
changes due to visual studio incompabilities:
- changed pragma in hashtable to attribute unused
- made memory barrier compiler independent
- defined attribute to do nothing in visual studio 