### PR TITLE
Refactor log facilities.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ SET(CJET_LINUX_FILES
 SET(CJET_POSIX_FILES
         posix/auth_file.c
         posix/jet_string.c
+        posix/log.c
         posix/main.c
         posix/socket.c
 )

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -33,7 +33,7 @@
 	__builtin_expect((x), 1)
 #define unlikely(x) \
 	__builtin_expect((x), 0)
-	
+
 #define RESTRICT restrict
 
 #elif _MSC_VER
@@ -42,7 +42,7 @@
 	(x)
 #define unlikely(x) \
 	(x)
-	
+
 #define RESTRICT __restrict
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -27,31 +27,16 @@
 #ifndef CJET_LOG_H
 #define CJET_LOG_H
 
-#ifdef TESTING
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void test_log(const char *format, ...);
-char *get_log_buffer(void);
+void log_err(const char *format, ...);
+void log_warn(const char *format, ...);
+void log_info(const char *format, ...);
 
 #ifdef __cplusplus
 }
-#endif
-
-#define log_err(...) test_log(__VA_ARGS__)
-#define log_warn(...) test_log(__VA_ARGS__)
-#define log_info(...) test_log(__VA_ARGS__)
-
-#else
-
-#include <syslog.h>
-
-#define log_err(...) syslog(LOG_ERR, __VA_ARGS__)
-#define log_warn(...) syslog(LOG_WARNING, __VA_ARGS__)
-#define log_info(...) syslog(LOG_INFO, __VA_ARGS__)
-
 #endif
 
 #endif

--- a/src/posix/log.c
+++ b/src/posix/log.c
@@ -1,7 +1,7 @@
 /*
- * The MIT License (MIT)
+ *The MIT License (MIT)
  *
- * Copyright (c) <2015> <Stephan Gatzka>
+ * Copyright (c) <2017> <Stephan Gatzka>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -26,46 +26,35 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <syslog.h>
 
 #include "log.h"
-#include "log_test.h"
 
-static const unsigned int LOG_BUFFER_SIZE = 1000;
-static char log_buffer[LOG_BUFFER_SIZE];
-
-char *get_log_buffer(void)
-{
-	return log_buffer;
-}
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+static char log_buffer[200];
 
 void log_err(const char *format, ...)
 {
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
+	va_list args;
+	va_start(args, format);
+	vsnprintf(log_buffer, sizeof(log_buffer), format, args);
+	syslog(LOG_ERR, "%s", log_buffer);
+	va_end(args);
 }
 
 void log_warn(const char *format, ...)
 {
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
+	va_list args;
+	va_start(args, format);
+	vsnprintf(log_buffer, sizeof(log_buffer), format, args);
+	syslog(LOG_WARNING, "%s", log_buffer);
+	va_end(args);
 }
 
 void log_info(const char *format, ...)
 {
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
+	va_list args;
+	va_start(args, format);
+	vsnprintf(log_buffer, sizeof(log_buffer), format, args);
+	syslog(LOG_INFO, "%s", log_buffer);
+	va_end(args);
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/posix/log.c
+++ b/src/posix/log.c
@@ -28,10 +28,12 @@
 #include <stdio.h>
 #include <syslog.h>
 
+#include "compiler.h"
 #include "log.h"
 
 static char log_buffer[200];
 
+__attribute__((format(printf, 1, 2)))
 void log_err(const char *format, ...)
 {
 	va_list args;
@@ -41,6 +43,7 @@ void log_err(const char *format, ...)
 	va_end(args);
 }
 
+__attribute__((format(printf, 1, 2)))
 void log_warn(const char *format, ...)
 {
 	va_list args;
@@ -50,6 +53,7 @@ void log_warn(const char *format, ...)
 	va_end(args);
 }
 
+__attribute__((format(printf, 1, 2)))
 void log_info(const char *format, ...)
 {
 	va_list args;

--- a/src/tests/log_test.h
+++ b/src/tests/log_test.h
@@ -1,7 +1,7 @@
 /*
- * The MIT License (MIT)
+ *The MIT License (MIT)
  *
- * Copyright (c) <2015> <Stephan Gatzka>
+ * Copyright (c) <2014> <Stephan Gatzka>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -24,48 +24,9 @@
  * SOFTWARE.
  */
 
-#include <stdarg.h>
-#include <stdio.h>
+#ifndef CJET_LOG_TEST_H
+#define CJET_LOG_TEST_H
 
-#include "log.h"
-#include "log_test.h"
+char *get_log_buffer(void);
 
-static const unsigned int LOG_BUFFER_SIZE = 1000;
-static char log_buffer[LOG_BUFFER_SIZE];
-
-char *get_log_buffer(void)
-{
-	return log_buffer;
-}
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void log_err(const char *format, ...)
-{
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
-}
-
-void log_warn(const char *format, ...)
-{
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
-}
-
-void log_info(const char *format, ...)
-{
-	va_list ap;
-	va_start(ap, format);
-	vsnprintf(log_buffer, LOG_BUFFER_SIZE, format, ap);
-	va_end(ap);
-}
-
-#ifdef __cplusplus
-}
 #endif

--- a/src/tests/peer_test.cpp
+++ b/src/tests/peer_test.cpp
@@ -31,6 +31,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "log.h"
+#include "log_test.h"
 #include "peer.h"
 
 extern "C" {


### PR DESCRIPTION
To ease porting to non-POSIX platforms, we just provide prototypes for
for the log function. No macros are involved anymore, so log.h does not
contain any platform specific ifdefs.