### PR TITLE
Correct const correctness of fetcher_table in element.

### DIFF
--- a/src/element.h
+++ b/src/element.h
@@ -48,7 +48,7 @@ struct element {
 	char *path;
 	struct peer *peer; /*The peer the state belongs to */
 	cJSON *value;      /* NULL if method */
-	const struct fetch **fetcher_table;
+	struct fetch **fetcher_table;
 	group_t fetch_groups;
 	group_t set_groups;
 	group_t call_groups;

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -426,7 +426,7 @@ static int state_matches(const struct element *e, const struct fetch *f)
 	return 1;
 }
 
-static int add_fetch_to_state(struct element *e, const struct fetch *f)
+static int add_fetch_to_state(struct element *e, struct fetch *f)
 {
 	for (unsigned int i = 0; i < e->fetch_table_size; i++) {
 		if (e->fetcher_table[i] == NULL) {
@@ -512,7 +512,7 @@ error:
 	return -1;
 }
 
-static int add_fetch_to_state_and_notify(const struct peer *p, struct element *e, const struct fetch *f)
+static int add_fetch_to_state_and_notify(const struct peer *p, struct element *e, struct fetch *f)
 {
 	if (!has_access(e->fetch_groups, f->peer->fetch_groups)) {
 		return 0;
@@ -569,7 +569,7 @@ static int get_element(const struct peer *p, const struct cJSON *request, const 
 	return 0;
 }
 
-static int add_fetch_to_states_in_peer(const struct peer *p, const struct fetch *f)
+static int add_fetch_to_states_in_peer(const struct peer *p, struct fetch *f)
 {
 	struct list_head *item;
 	struct list_head *tmp;
@@ -609,7 +609,7 @@ int notify_fetchers(const struct element *e, const char *event_name)
 	return 0;
 }
 
-cJSON *add_fetch_to_states(const struct peer *request_peer, const cJSON *request, const struct fetch *f)
+cJSON *add_fetch_to_states(const struct peer *request_peer, const cJSON *request, struct fetch *f)
 {
 	struct list_head *item;
 	struct list_head *tmp;

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -59,7 +59,7 @@ int add_fetch_to_peer(struct peer *p, const cJSON *request, struct fetch **fetch
 cJSON *get_elements(const cJSON *request, const struct peer *request_peer);
 cJSON *remove_fetch_from_peer(const struct peer *p, const cJSON *request);
 void remove_all_fetchers_from_peer(struct peer *p);
-cJSON *add_fetch_to_states(const struct peer *request_peer, const cJSON *request, const struct fetch *f);
+cJSON *add_fetch_to_states(const struct peer *request_peer, const cJSON *request, struct fetch *f);
 int find_fetchers_for_element(struct element *e);
 
 int notify_fetchers(const struct element *e, const char *event_name);


### PR DESCRIPTION
This fetcher_table is free'd separately by passing to cjet_free(), so
it cannot be const.