### PR TITLE
bugfix: sub-protocol allows NULL

### DIFF
--- a/src/tests/websocket_test.cpp
+++ b/src/tests/websocket_test.cpp
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(test_websocket_init_without_subprotocols)
 {
 	struct websocket ws;
 	int ret = websocket_init(&ws, NULL, true, ws_on_error, NULL);
-	BOOST_CHECK_MESSAGE(ret == -1, "Initializaton of websocket did not failed when called without supported sub-protocol!");
+	BOOST_CHECK_MESSAGE(ret == 0, "Initializaton of websocket did not failed when called without supported sub-protocol!");
 }
 
 BOOST_FIXTURE_TEST_CASE(http_upgrade_with_websocket_protocol, F)

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -370,20 +370,29 @@ static int send_upgrade_response(struct http_connection *connection)
 
 	static const char switch_response_end[] = CRLF CRLF;
 
-	struct socket_io_vector iov[5];
-	iov[0].iov_base = switch_response;
-	iov[0].iov_len = sizeof(switch_response) - 1;
-	iov[1].iov_base = accept_value;
-	iov[1].iov_len = sizeof(accept_value);
-	iov[2].iov_base = ws_protocol;
-	iov[2].iov_len = sizeof(ws_protocol) - 1;
-	iov[3].iov_base = s->sub_protocol.name;
-	iov[3].iov_len = strlen(s->sub_protocol.name);
-	iov[4].iov_base = switch_response_end;
-	iov[4].iov_len = sizeof(switch_response_end) - 1;
+    struct socket_io_vector iov[5];
+    size_t iov_length = 5;
 
-	struct buffered_reader *br = &connection->br;
-	return br->writev(br->this_ptr, iov, ARRAY_SIZE(iov));
+    iov[0].iov_base = switch_response;
+    iov[0].iov_len = sizeof(switch_response) - 1;
+    iov[1].iov_base = accept_value;
+    iov[1].iov_len = sizeof(accept_value);
+    iov[2].iov_base = ws_protocol;
+    iov[2].iov_len = sizeof(ws_protocol) - 1;
+
+    if (s->sub_protocol.name != NULL){
+        iov[3].iov_base = s->sub_protocol.name;
+        iov[3].iov_len = strlen(s->sub_protocol.name);
+        iov[4].iov_base = switch_response_end;
+        iov[4].iov_len = sizeof(switch_response_end) - 1;
+    } else {
+        iov_length = 4;
+        iov[3].iov_base = switch_response_end;
+        iov[3].iov_len = sizeof(switch_response_end) - 1;
+    }
+
+    struct buffered_reader *br = &connection->br;
+    return br->writev(br->this_ptr, iov, iov_length);
 }
 
 int websocket_upgrade_on_header_field(http_parser *p, const char *at, size_t length)
@@ -598,8 +607,8 @@ int websocket_send_close_frame(const struct websocket *s, enum ws_status_code st
 int websocket_init(struct websocket *ws, struct http_connection *connection, bool is_server, void (*on_error)(struct websocket *s), const char *sub_protocol)
 {
 	if (unlikely(sub_protocol == NULL)) {
-		log_err("You must specify a sub-protocol");
-		return -1;
+        log_info("No sub-protocol specified");
+//		return -1;
 	}
 	if (unlikely(on_error == NULL)) {
 		log_err("You must specify an error routine");

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -360,39 +360,39 @@ static int send_upgrade_response(struct http_connection *connection)
 	b64_encode_string(sha1_buffer, SHA1HashSize, accept_value);
 
 	static const char switch_response[] =
-	    "HTTP/1.1 101 Switching Protocols" CRLF
-	    "Upgrade: websocket" CRLF
-	    "Connection: Upgrade" CRLF
-	    "Sec-WebSocket-Accept: ";
+		"HTTP/1.1 101 Switching Protocols" CRLF
+		"Upgrade: websocket" CRLF
+		"Connection: Upgrade" CRLF
+		"Sec-WebSocket-Accept: ";
 
 	static const char ws_protocol[] =
-	    CRLF "Sec-Websocket-Protocol: ";
+		CRLF "Sec-Websocket-Protocol: ";
 
 	static const char switch_response_end[] = CRLF CRLF;
 
-    struct socket_io_vector iov[5];
-    size_t iov_length = 5;
+	struct socket_io_vector iov[5];
+	size_t iov_length = 5;
 
-    iov[0].iov_base = switch_response;
-    iov[0].iov_len = sizeof(switch_response) - 1;
-    iov[1].iov_base = accept_value;
-    iov[1].iov_len = sizeof(accept_value);
-    iov[2].iov_base = ws_protocol;
-    iov[2].iov_len = sizeof(ws_protocol) - 1;
+	iov[0].iov_base = switch_response;
+	iov[0].iov_len = sizeof(switch_response) - 1;
+	iov[1].iov_base = accept_value;
+	iov[1].iov_len = sizeof(accept_value);
+	iov[2].iov_base = ws_protocol;
+	iov[2].iov_len = sizeof(ws_protocol) - 1;
 
-    if (s->sub_protocol.name != NULL){
-        iov[3].iov_base = s->sub_protocol.name;
-        iov[3].iov_len = strlen(s->sub_protocol.name);
-        iov[4].iov_base = switch_response_end;
-        iov[4].iov_len = sizeof(switch_response_end) - 1;
-    } else {
-        iov_length = 4;
-        iov[3].iov_base = switch_response_end;
-        iov[3].iov_len = sizeof(switch_response_end) - 1;
-    }
+	if (s->sub_protocol.name != NULL){
+		iov[3].iov_base = s->sub_protocol.name;
+		iov[3].iov_len = strlen(s->sub_protocol.name);
+		 iov[4].iov_base = switch_response_end;
+		iov[4].iov_len = sizeof(switch_response_end) - 1;
+	} else {
+		iov_length = 4;
+		iov[3].iov_base = switch_response_end;
+		iov[3].iov_len = sizeof(switch_response_end) - 1;
+	}
 
-    struct buffered_reader *br = &connection->br;
-    return br->writev(br->this_ptr, iov, iov_length);
+	struct buffered_reader *br = &connection->br;
+	return br->writev(br->this_ptr, iov, iov_length);
 }
 
 int websocket_upgrade_on_header_field(http_parser *p, const char *at, size_t length)


### PR DESCRIPTION
NULL is now accepted by websocket.c as sub-protocol. If it is NULL, a info message is send to log.