### PR TITLE
Increase max message size

### DIFF
--- a/qbs/modules/generateCjetConfig/generateCjetConfig.qbs
+++ b/qbs/modules/generateCjetConfig/generateCjetConfig.qbs
@@ -63,7 +63,7 @@ Module {
         content = content.replace(/\${CONFIG_JET_PORT}/g, product.moduleProperty("generateCjetConfig", "jetPort") || "11122");
         content = content.replace(/\${CONFIG_JETWS_PORT}/g, product.moduleProperty("generateCjetConfig", "jetwsPort") || "11123");
         content = content.replace(/\${CONFIG_LISTEN_BACKLOG}/g, product.moduleProperty("generateCjetConfig", "maxListenBacklog") || "40");
-        content = content.replace(/\${CONFIG_MAX_MESSAGE_SIZE}/g, product.moduleProperty("generateCjetConfig", "maxMessageSize") || "512");
+        content = content.replace(/\${CONFIG_MAX_MESSAGE_SIZE}/g, product.moduleProperty("generateCjetConfig", "maxMessageSize") || "262144");
         content = content.replace(/\${CONFIG_MAX_WRITE_BUFFER_SIZE}/g, product.moduleProperty("generateCjetConfig", "maxWriteBufferSize") || "5120");
         content = content.replace(/\${CONFIG_ELEMENT_TABLE_ORDER}/g, product.moduleProperty("generateCjetConfig", "stateTableOrder") || "13");
         content = content.replace(/\${CONFIG_ROUTING_TABLE_ORDER}/g, product.moduleProperty("generateCjetConfig", "routingTableOrder") || "6");

--- a/src/buffered_socket.c
+++ b/src/buffered_socket.c
@@ -406,10 +406,8 @@ int buffered_socket_read_exactly(void *this_ptr, size_t num,
 			return 0;
 		} else if (ret < 0) {
 			error_function(&bs->ev);
-			return -1;
-		} else {
-			return -1;
 		}
+		return 0;
 	}
 }
 
@@ -437,9 +435,7 @@ int buffered_socket_read_until(void *this_ptr, const char *delim,
 			return 0;
 		} else if (ret < 0) {
 			error_function(&bs->ev);
-			return -1;
-		} else {
-			return -1;
 		}
+		return 0;
 	}
 }

--- a/src/tests/buffered_socket_test.cpp
+++ b/src/tests/buffered_socket_test.cpp
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE(test_read_exactly_buffer_wrap)
 		size_t chunks = (CONFIG_MAX_MESSAGE_SIZE / chunk_size) + 1;
 		char buffer[chunk_size * chunks];
 		::memset(buffer, 0, sizeof(buffer));
-		readbuffer=buffer;
+		readbuffer = buffer;
 		readbuffer_length = sizeof(buffer);
 		F f(READ_COMPLETE_BUFFER);
 		int ret = buffered_socket_read_exactly(f.bs, chunk_size, f.read_callback, &f);

--- a/src/tests/buffered_socket_test.cpp
+++ b/src/tests/buffered_socket_test.cpp
@@ -703,9 +703,10 @@ BOOST_AUTO_TEST_CASE(test_read_exactly_called_twice)
 BOOST_AUTO_TEST_CASE(test_read_exactly_buffer_wrap)
 {
 	for (unsigned int chunk_size = 1; chunk_size <= CONFIG_MAX_MESSAGE_SIZE; chunk_size++) {
-		size_t chunks = (CONFIG_MAX_MESSAGE_SIZE / chunk_size) + 1; 
+		size_t chunks = (CONFIG_MAX_MESSAGE_SIZE / chunk_size) + 1;
 		char buffer[chunk_size * chunks];
 		::memset(buffer, 0, sizeof(buffer));
+		readbuffer=buffer;
 		readbuffer_length = sizeof(buffer);
 		F f(READ_COMPLETE_BUFFER);
 		int ret = buffered_socket_read_exactly(f.bs, chunk_size, f.read_callback, &f);

--- a/src/tests/buffered_socket_test.cpp
+++ b/src/tests/buffered_socket_test.cpp
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE(test_read_exactly_more_than_buffer)
 	F f(READ_FULL);
 	size_t read_size = CONFIG_MAX_MESSAGE_SIZE + 1;
 	int ret = buffered_socket_read_exactly(f.bs, read_size, f.read_callback, &f);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK(ret == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_read_exactly_read_close)
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(test_read_exactly_read_close)
 	F f(READ_CLOSE);
 	size_t read_size = 4;
 	int ret = buffered_socket_read_exactly(f.bs, read_size, f.read_callback, &f);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK(ret == 0);
 	BOOST_CHECK(f.readcallback_called == 1);
 	BOOST_CHECK(f.read_len == 0);
 }
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE(test_read_exactly_read_error)
 	F f(READ_ERROR);
 	size_t read_size = 4;
 	int ret = buffered_socket_read_exactly(f.bs, read_size, f.read_callback, &f);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK(ret == 0);
 	BOOST_CHECK(f.readcallback_called == 0);
 }
 
@@ -906,7 +906,7 @@ BOOST_AUTO_TEST_CASE(test_read_until_more_than_buffer)
 	readbuffer_length = sizeof(buffer);
 	F f(READ_COMPLETE_BUFFER);
 	int ret = buffered_socket_read_until(f.bs, "\r\n", f.read_callback, &f);
-	BOOST_CHECK(ret == -1);
+	BOOST_CHECK(ret == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_read_until_buffer_wrap)


### PR DESCRIPTION
Increased read buffer size to 262144 to match the message sizes from autobahn-testsuite. 
The read functions of buffered_socket return 0 now if a problem occures during go_reading, because the error-function handle that. Due to that the unittests has been adaptet and an uninitialized pointer is set now.