### PR TITLE
Add ping payload check and changed ws_close statuscode

### DIFF
--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(test_receive_close_message_on_server)
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 	BOOST_CHECK_MESSAGE(close_received_called, "Callback for close message was not called!");
 	BOOST_CHECK_MESSAGE(status_code_received == code, "Incorrect status code received!");
-	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_GOING_AWAY), "No close frame sent receiving a close!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_NORMAL), "No close frame sent receiving a close!");
 	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
 }
 
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE(test_receive_fin_on_server)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 	prepare_message(WS_OPCODE_CLOSE, NULL, 0, is_server, mask);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
-	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_GOING_AWAY), "No close frame sent after receiving a close frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_NORMAL), "No close frame sent after receiving a close frame!");
 	BOOST_CHECK_MESSAGE(close_received_called, "Callback for close message was not called after receiving a close frame!");
 	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
 }

--- a/src/tests/websocket_peer_test.cpp
+++ b/src/tests/websocket_peer_test.cpp
@@ -290,7 +290,7 @@ BOOST_FIXTURE_TEST_CASE(test_connection_closed_when_receiving_fin, F)
 	ws_get_header(socket, read_buffer_ptr++, read_buffer_length);
 
 	BOOST_CHECK_MESSAGE(num_close_called == 1, "Close of buffered_reader was not called when receiving a close frame!");
-	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_GOING_AWAY), "No close frame sent when receiving a close frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_NORMAL), "No close frame sent when receiving a close frame!");
 }
 
 BOOST_FIXTURE_TEST_CASE(test_connection_closed_when_illegal_message, F)

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -99,13 +99,18 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 		break;
 
 	case WS_PING_FRAME: {
-		int pong_ret = websocket_send_pong_frame(s, frame, length);
-		if (unlikely(pong_ret < 0)) {
-			// TODO: maybe call the error callback?
-			ret = WS_ERROR;
+		if (unlikely(length > 125)) {
+			handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
+			ret = WS_CLOSED;
 		} else {
-			if (s->ping_received != NULL) {
-				ret = s->ping_received(s, frame, length);
+			int pong_ret = websocket_send_pong_frame(s, frame, length);
+			if (unlikely(pong_ret < 0)) {
+				// TODO: maybe call the error callback?
+				ret = WS_ERROR;
+			} else {
+				if (s->ping_received != NULL) {
+					ret = s->ping_received(s, frame, length);
+				}
 			}
 		}
 		break;

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -123,7 +123,7 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 			memcpy(&status_code, frame, sizeof(status_code));
 			status_code = jet_be16toh(status_code);
 		}
-		websocket_close(s, WS_CLOSE_GOING_AWAY);
+		websocket_close(s, WS_CLOSE_NORMAL);
 		if (s->close_received != NULL) {
 			s->close_received(s, (enum ws_status_code)status_code);
 		}


### PR DESCRIPTION
Pings with a payload greater than 125 are not allowed by ws protocol. the connection will be closed with error code 1002. 

The statuscode for ws_close_frames is changed from going_away (1001) to close_normal (1000). It is not specified by RFC but used in the autobahn tests and firefox.