### PR TITLE
RSV-bit handling and test. Test for to large ping

### DIFF
--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(test_receive_ping_frame_on_server)
 	BOOST_CHECK_MESSAGE(is_pong_frame(message), "No pong frame sent when ping received!");
 }
 
-BOOST_AUTO_TEST_CASE(test_recieve_to_large_ping_frame_on_server)
+BOOST_AUTO_TEST_CASE(test_recieve_to_large_ping_payload_on_server)
 {
 	bool is_server = true;
 	F f(is_server, 5000);

--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_receive_text_message_with_rsv_bit_set)
 
 	char message [] = "Hello World!";
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
-	for (uint8_t rsv = 0x10; rsv <= 0x70; rsv+=16){
+	for (uint8_t rsv = 0x10; rsv <= 0x70; rsv += 0x10){
 		F f(is_server, 5000);
 		const uint8_t type = WS_OPCODE_TEXT | rsv;
 		prepare_message_string(type, message, is_server, mask);

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -71,7 +71,7 @@ static void handle_error(struct websocket *s, uint16_t status_code)
 
 static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8_t *frame, size_t length)
 {
-	if (s->ws_flags.rsv != 0) {
+	if (unlikely(s->ws_flags.rsv != 0)) {
 		handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 		return WS_CLOSED;
 	}

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -79,6 +79,7 @@ struct websocket {
 
 	struct {
 		unsigned int fin : 1;
+		unsigned int rsv : 3;
 		unsigned int opcode : 4;
 		unsigned int mask : 1;
 	} ws_flags;


### PR DESCRIPTION
RSV-bits are read by header and if any is not 0, the connection is failed immediately with error-code 1002. A Unit test is written in websocket_frame_test as well as one for pings with to large payload.