### PR TITLE
Changed closing statuscode for frame with reserved opcode

### DIFF
--- a/src/tests/websocket_peer_test.cpp
+++ b/src/tests/websocket_peer_test.cpp
@@ -306,5 +306,5 @@ BOOST_FIXTURE_TEST_CASE(test_connection_closed_when_illegal_message, F)
 	ws_get_header(socket, read_buffer_ptr++, read_buffer_length);
 
 	BOOST_CHECK_MESSAGE(num_close_called == 1, "Close of buffered_reader was not called when receiving an illegal frame!");
-	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_UNSUPPORTED), "No close frame sent when receiving an illegal frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_PROTOCOL_ERROR), "No close frame sent when receiving an illegal frame!");
 }

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -142,8 +142,8 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 	}
 
 	default:
-		log_err("Unsupported websocket frame!\n");
-		handle_error(s, WS_CLOSE_UNSUPPORTED);
+		log_err("Unsupported websocket frame with reserved opcode!\n");
+		handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 		ret = WS_CLOSED;
 		break;
 	}


### PR DESCRIPTION
closing status code for frames with reserved opcodes are changed
from close_unsupported (1003) to close_error (1002). Tests are adaptet.