### PR TITLE
Add fragmentation handling to websocket

### DIFF
--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -332,6 +332,7 @@ static void fill_payload(uint8_t *ptr, const uint8_t *payload, uint64_t length, 
 static void prepare_message(uint8_t type, uint8_t *buffer, uint64_t length, bool shall_mask, uint8_t mask[4], bool set_fin)
 {
 	uint8_t *ptr = read_buffer;
+	read_buffer_ptr = read_buffer;
 	read_buffer_length = 0;
 	uint8_t header = 0x00;
 	if (set_fin) {
@@ -505,11 +506,9 @@ BOOST_AUTO_TEST_CASE(test_receive_text_frames)
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
@@ -529,11 +528,9 @@ BOOST_AUTO_TEST_CASE(test_recceive_binary_frames)
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
@@ -552,15 +549,12 @@ BOOST_AUTO_TEST_CASE(test_receive_text_frames_with_ping_in_between)
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_PING, messages[3], is_server, mask, true);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
@@ -579,7 +573,6 @@ BOOST_AUTO_TEST_CASE(test_receive_text_frames_without_start_frame)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	BOOST_CHECK_MESSAGE(text_frame_received_called == 0, "Callback for text frames was called: " << text_frame_received_called);
@@ -598,7 +591,6 @@ BOOST_AUTO_TEST_CASE(test_receive_text_frame_only_end_frame)
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
 
 	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	BOOST_CHECK_MESSAGE(text_frame_received_called == 0, "Callback for text frames was called: " << text_frame_received_called);
@@ -619,7 +611,6 @@ BOOST_AUTO_TEST_CASE(test_receive_text_frames_with_opcode)
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	prepare_message_string_frag(WS_OPCODE_TEXT, messages[1], is_server, mask, false);
-	read_buffer_ptr = read_buffer;
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 
 	BOOST_CHECK_MESSAGE(text_frame_received_called == 1, "Callback for text frames was called: " << text_frame_received_called);

--- a/src/tests/websocket_frame_test.cpp
+++ b/src/tests/websocket_frame_test.cpp
@@ -46,6 +46,7 @@ static const uint8_t WS_HEADER_FIN = 0x80;
 static const uint8_t WS_HEADER_RSV = 0x70;
 static const uint8_t WS_HEADER_MASK = 0x80;
 
+static const uint8_t WS_OPCODE_CONTINUATION = 0x00;
 static const uint8_t WS_OPCODE_TEXT = 0x01;
 static const uint8_t WS_OPCODE_BINARY = 0x02;
 static const uint8_t WS_OPCODE_CLOSE = 0x08;
@@ -64,7 +65,9 @@ static size_t readback_buffer_length;
 static bool br_close_called;
 static bool got_error;
 static bool text_message_received_called;
+static int text_frame_received_called;
 static bool binary_message_received_called;
+static int binary_frame_received_called;
 static bool ping_received_called;
 static bool pong_received_called;
 static bool close_received_called;
@@ -255,6 +258,18 @@ static enum websocket_callback_return text_message_received(struct websocket *s,
 	return WS_OK;
 }
 
+static enum websocket_callback_return text_frame_received(struct websocket *s, char *msg, size_t length, bool last_frame)
+{
+	(void)s;
+	::memcpy(readback_buffer + readback_buffer_length, msg, length);
+	readback_buffer_length += length;
+	if (last_frame) {
+		//do nothing
+	}
+	text_frame_received_called++;
+	return WS_OK;
+}
+
 static enum websocket_callback_return binary_message_received(struct websocket *s, uint8_t *msg, size_t length)
 {
 	(void)s;
@@ -264,12 +279,24 @@ static enum websocket_callback_return binary_message_received(struct websocket *
 	return WS_OK;
 }
 
+static enum websocket_callback_return binary_frame_received(struct websocket *s, uint8_t *msg, size_t length, bool last_frame)
+{
+	(void)s;
+	::memcpy(readback_buffer + readback_buffer_length, msg, length);
+	readback_buffer_length += length;
+	if (last_frame) {
+		//do nothing
+	}
+	binary_frame_received_called++;
+	return WS_OK;
+}
+
 static enum websocket_callback_return ping_received(struct websocket *s, uint8_t *msg, size_t length)
 {
 	(void)s;
 	(void)msg;
 	(void)length;
-	::memcpy(readback_buffer, msg, length);
+	::memcpy(readback_buffer + readback_buffer_length, msg, length);
 	readback_buffer_length += length;
 	ping_received_called = true;
 	return WS_OK;
@@ -302,12 +329,14 @@ static void fill_payload(uint8_t *ptr, const uint8_t *payload, uint64_t length, 
 	}
 }
 
-static void prepare_message(uint8_t type, uint8_t *buffer, uint64_t length, bool shall_mask, uint8_t mask[4])
+static void prepare_message(uint8_t type, uint8_t *buffer, uint64_t length, bool shall_mask, uint8_t mask[4], bool set_fin)
 {
 	uint8_t *ptr = read_buffer;
 	read_buffer_length = 0;
 	uint8_t header = 0x00;
-	header |= WS_HEADER_FIN;
+	if (set_fin) {
+		header |= WS_HEADER_FIN;
+	}
 	header |= type;
 	::memcpy(ptr, &header, sizeof(header));
 	ptr += sizeof(header);
@@ -355,7 +384,12 @@ static void prepare_message(uint8_t type, uint8_t *buffer, uint64_t length, bool
 
 static void prepare_message_string(uint8_t type, const char *message, bool shall_mask, uint8_t mask[4])
 {
-	prepare_message(type, (uint8_t *)message, ::strlen(message), shall_mask, mask);
+	prepare_message(type, (uint8_t *)message, ::strlen(message), shall_mask, mask, true);
+}
+
+static void prepare_message_string_frag(uint8_t type, const char *message, bool shall_mask, uint8_t mask[4], bool set_fin)
+{
+	prepare_message(type, (uint8_t *)message, ::strlen(message), shall_mask, mask, set_fin);
 }
 
 struct F {
@@ -367,7 +401,9 @@ struct F {
 		br_close_called = false;
 		got_error = false;
 		text_message_received_called = false;
+		text_frame_received_called = 0;
 		binary_message_received_called = false;
+		binary_frame_received_called = 0;
 		ping_received_called = false;
 		close_received_called = false;
 		pong_received_called = false;
@@ -395,6 +431,8 @@ struct F {
 		ws.upgrade_complete = true;
 		ws.text_message_received = text_message_received;
 		ws.binary_message_received = binary_message_received;
+		ws.text_frame_received = text_frame_received;
+		ws.binary_frame_received = binary_frame_received;
 		ws.ping_received = ping_received;
 		ws.pong_received = pong_received;
 		ws.close_received = close_received;
@@ -454,6 +492,159 @@ BOOST_AUTO_TEST_CASE(test_receive_binary_message)
 			BOOST_CHECK_MESSAGE(::strncmp(messages[i], (char *)readback_buffer, readback_buffer_length) == 0, "Did not received the same message as sent!");
 		}
 	}
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_text_frames)
+{
+	const char *messages[3] = {"frag1", "frag2", "frag3"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_TEXT, messages[0], is_server, mask, false);
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 3, "Callback for text frames was not or wrong times called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(::strncmp("frag1frag2frag3", (char *)readback_buffer, 15) == 0, "Did not received the same message as sent!");
+
+}
+
+BOOST_AUTO_TEST_CASE(test_recceive_binary_frames)
+{
+	const char *messages[3] = {"frag1", "frag2", "frag3"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_BINARY, messages[0], is_server, mask, false);
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
+	BOOST_CHECK_MESSAGE(binary_frame_received_called == 3, "Callback for binary frames was not or wrong times called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(::strncmp("frag1frag2frag3", (char *)readback_buffer, 15) == 0, "Did not received the same message as sent!");
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_text_frames_with_ping_in_between)
+{
+	const char *messages[4] = {"frag1", "frag2", "frag3", "ping"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_TEXT, messages[0], is_server, mask, false);
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_PING, messages[3], is_server, mask, true);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	websocket_close(&f.ws, WS_CLOSE_GOING_AWAY);
+
+	BOOST_CHECK_MESSAGE(ping_received_called, "Callback for ping messages was not called!");
+	BOOST_CHECK_MESSAGE(is_pong_frame(messages[3]), "No pong frame sent when ping received!");
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 3, "Callback for text frames was not or wrong times called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(::strncmp("frag1frag2pingfrag3", (char *)readback_buffer, 19) == 0, "Did not received the same message as sent!: " << readback_buffer);
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_text_frames_without_start_frame)
+{
+	const char *messages[3] = {"frag1", "frag2", "frag3"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[1], is_server, mask, false);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 0, "Callback for text frames was called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(got_error, "Did not got an error when receiving a message without start frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_PROTOCOL_ERROR), "No close frame sent after error!");
+	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
+	BOOST_CHECK_MESSAGE(readback_buffer_length == 0, "Received a message!");
+
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_text_frame_only_end_frame)
+{
+	const char *messages[3] = {"frag1", "frag2", "frag3"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_CONTINUATION, messages[2], is_server, mask, true);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 0, "Callback for text frames was called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(got_error, "Did not got an error when receiving a message without start frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_PROTOCOL_ERROR), "No close frame sent after error!");
+	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
+	BOOST_CHECK_MESSAGE(readback_buffer_length == 0, "Received a message!");
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_text_frames_with_opcode)
+{
+	const char *messages[3] = {"frag1", "frag2", "frag3"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_TEXT, messages[0], is_server, mask, false);
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	prepare_message_string_frag(WS_OPCODE_TEXT, messages[1], is_server, mask, false);
+	read_buffer_ptr = read_buffer;
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 1, "Callback for text frames was called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(got_error, "Did not got an error when receiving a message without start frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_PROTOCOL_ERROR), "No close frame sent after error!");
+	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
+	BOOST_CHECK_MESSAGE(::strncmp("frag1", (char *)readback_buffer, 5) == 0, "Did not received the same message as sent!: " << readback_buffer);
+}
+
+BOOST_AUTO_TEST_CASE(test_receive_fragmented_ping)
+{
+	const char *messages[3] = {"controll frames", "must not", "be fragmented"};
+	bool is_server = true;
+	F f(is_server, 5000);
+	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
+
+	prepare_message_string_frag(WS_OPCODE_PING, messages[0], is_server, mask, false);
+	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
+
+	BOOST_CHECK_MESSAGE(text_frame_received_called == 0, "Callback for text frames was called: " << text_frame_received_called);
+	BOOST_CHECK_MESSAGE(!ping_received_called, "Callback for ping frame was called!");
+	BOOST_CHECK_MESSAGE(got_error, "Did not got an error when receiving a message without start frame!");
+	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_PROTOCOL_ERROR), "No close frame sent after error!");
+	BOOST_CHECK_MESSAGE(br_close_called, "buffered_reader not closed after websocket close!");
+	BOOST_CHECK_MESSAGE(readback_buffer_length == 0, "Received a message!");
 }
 
 BOOST_AUTO_TEST_CASE(test_receive_ping_frame_on_server)
@@ -729,7 +920,7 @@ BOOST_AUTO_TEST_CASE(test_receive_fin_on_server)
 	F f(is_server, 5000);
 
 	uint8_t mask[4] = {0xaa, 0x55, 0xcc, 0x11};
-	prepare_message(WS_OPCODE_CLOSE, NULL, 0, is_server, mask);
+	prepare_message(WS_OPCODE_CLOSE, NULL, 0, is_server, mask, true);
 	ws_get_header(&f.ws, read_buffer_ptr++, read_buffer_length);
 	BOOST_CHECK_MESSAGE(is_close_frame(WS_CLOSE_NORMAL), "No close frame sent after receiving a close frame!");
 	BOOST_CHECK_MESSAGE(close_received_called, "Callback for close message was not called after receiving a close frame!");

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -72,10 +72,16 @@ static void handle_error(struct websocket *s, uint16_t status_code)
 static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8_t *frame, size_t length)
 {
 	if (unlikely(s->ws_flags.rsv != 0)) {
+		log_err("Frame with RSV-bit are not supported");
 		handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 		return WS_CLOSED;
 	}
 
+	if (unlikely((s->ws_flags.fin == 0) && (s->ws_flags.opcode >= WS_PING_FRAME))) {
+		log_err("Control Frames must not be fragmented!");
+		handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
+		return WS_CLOSED;
+	}
 	enum websocket_callback_return ret = WS_OK;
 
 	switch (s->ws_flags.opcode) {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -42,7 +42,6 @@
 
 static const uint8_t WS_MASK_SET = 0x80;
 static const uint8_t WS_HEADER_FIN = 0x80;
-static unsigned int fragment_opcode = 0xff;
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
@@ -86,28 +85,26 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 
 	if (s->ws_flags.fin == 0) {
 		if (s->ws_flags.opcode !=0) {
-			if (unlikely(fragment_opcode != 0xff)) {
+			if (unlikely(s->ws_flags.is_fragmented)) {
 				log_err("Overwriting Opcode of unfinished fragmentation!");
-				fragment_opcode = 0xff;
 				handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 				return WS_CLOSED;
 			}
-			fragment_opcode = s->ws_flags.opcode;
+			s->ws_flags.is_fragmented = 1;
+			s->ws_flags.frag_opcode = s->ws_flags.opcode;
 			s->ws_flags.opcode = WS_CONTINUATION_FRAME;
 		} else {
-			if (unlikely(fragment_opcode == 0xff)) {
-				log_err("Opcode unknown!");
-				fragment_opcode = 0xff;
+			if (unlikely(!(s->ws_flags.is_fragmented))) {
+				log_err("No start frame was send!");
 				handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 				return WS_CLOSED;
 			}
 		}
 	}
 
-	if (fragment_opcode != 0xff) {
+	if (s->ws_flags.is_fragmented) {
 		if (unlikely((s->ws_flags.opcode < WS_PING_FRAME) && (s->ws_flags.opcode > 0))) {
 			log_err("Opcode during fragmentation must be 0x0!");
-			fragment_opcode = 0xff;
 			handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 			return WS_CLOSED;
 		}
@@ -120,7 +117,7 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 		if (unlikely(s->ws_flags.fin ==1)) {
 			last_frame = true;
 		}
-		switch (fragment_opcode) {
+		switch (s->ws_flags.frag_opcode) {
 		case WS_BINARY_FRAME:
 			ret = s->binary_frame_received(s, frame, length, last_frame);
 			break;
@@ -129,12 +126,14 @@ static enum websocket_callback_return ws_handle_frame(struct websocket *s, uint8
 			break;
 		default:
 			log_err("Opcode unknown!");
-			fragment_opcode = 0xff;
 			handle_error(s, WS_CLOSE_PROTOCOL_ERROR);
 			ret = WS_CLOSED;
 			break;
 		}
-		if (last_frame) fragment_opcode = 0xff;
+		if (last_frame) {
+			s->ws_flags.is_fragmented = 0;
+			s->ws_flags.frag_opcode = WS_CONTINUATION_FRAME;
+		}
 		break;
 
 	case WS_BINARY_FRAME:
@@ -691,6 +690,8 @@ int websocket_init(struct websocket *ws, struct http_connection *connection, boo
 	ws->upgrade_complete = false;
 
 	ws->sub_protocol.name = sub_protocol;
+	ws->ws_flags.is_fragmented = 0;
+	ws->ws_flags.frag_opcode = WS_CONTINUATION_FRAME;
 	return 0;
 }
 

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -82,6 +82,8 @@ struct websocket {
 		unsigned int rsv : 3;
 		unsigned int opcode : 4;
 		unsigned int mask : 1;
+		unsigned int frag_opcode : 4;
+		unsigned int is_fragmented : 1;
 	} ws_flags;
 	uint64_t length;
 	uint8_t mask[4];

--- a/src/websocket_peer.c
+++ b/src/websocket_peer.c
@@ -83,7 +83,7 @@ static void free_websocket_peer_on_error(void *context)
 	free_websocket_peer(ws_peer);
 }
 
-static enum websocket_callback_return text_frame_callback(struct websocket *s, char *msg, size_t length)
+static enum websocket_callback_return text_message_callback(struct websocket *s, char *msg, size_t length)
 {
 	struct websocket_peer *ws_peer = container_of(s, struct websocket_peer, websocket);
 	int ret = parse_message(msg, length, &ws_peer->peer);
@@ -134,7 +134,7 @@ static int init_websocket_peer(struct websocket_peer *ws_peer, struct http_conne
 	if (ret < 0) {
 		return -1;
 	}
-	ws_peer->websocket.text_message_received = text_frame_callback;
+	ws_peer->websocket.text_message_received = text_message_callback;
 	ws_peer->websocket.close_received = close_callback;
 	ws_peer->websocket.pong_received = pong_received;
 


### PR DESCRIPTION
including seven unit-tests. The fragmented messages are passed to the websocket_peer to reassemble them.